### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,30 +7,30 @@
 #######################################
 
 PWMsense	KEYWORD1
-PWMinfo		KEYWORD1
-Pulse		KEYWORD1
-Cycle		KEYWORD1
+PWMinfo	KEYWORD1
+Pulse	KEYWORD1
+Cycle	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 ## PWMsense
-begin			KEYWORD2
-end				KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
 timeCounting	KEYWORD2
-pulseCount		KEYWORD2
-dutyCycle		KEYWORD2
-prf				KEYWORD2
-reset			KEYWORD2
+pulseCount	KEYWORD2
+dutyCycle	KEYWORD2
+prf	KEYWORD2
+reset	KEYWORD2
 
 ## PWMinfo
-begin			KEYWORD2
-end				KEYWORD2
-valid			KEYWORD2
-dutyCycle		KEYWORD2
-prf				KEYWORD2
-reset			KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+valid	KEYWORD2
+dutyCycle	KEYWORD2
+prf	KEYWORD2
+reset	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords