### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Dejan Gjorgjevikj <dejan.gjorgjevikj@gmail.com>
 maintainer=Dejan Gjorgjevikj <dejan.gjorgjevikj@gmail.com>
 sentence=Arduino PWM (duty and frequency) sensing library.
 paragraph=Arduino PWM (duty and frequency) sensing library.
-category=Signal
+category=Signal Input/Output
 url=https://github.com/Gjorgjevikj/PWMsense.git
 architectures=*


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Signal' in library PWMsenseis not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format